### PR TITLE
feat: show tip moniker

### DIFF
--- a/pages/api/transfer-og.tsx
+++ b/pages/api/transfer-og.tsx
@@ -29,6 +29,8 @@ const og = async (req: NextRequest) => {
   const { searchParams } = req.nextUrl
   const ogData = searchParams.get('data') ?? '{}'
   const data = JSON.parse(decodeURIComponent(ogData))
+  const unitCurrency = data.moniker ? data.moniker : data.symbol
+  const amount = !data.amount ? '???' : data.moniker ? data.original_amount : data.amount
 
   const regular = await regularFont
   const bold = await boldFont
@@ -189,7 +191,7 @@ const og = async (req: NextRequest) => {
                         fontSize: 32,
                       }}
                     >
-                      {!data.amount ? '???' : data.amount}
+                      {amount}
                     </span>
                     <span
                       style={{
@@ -201,7 +203,7 @@ const og = async (req: NextRequest) => {
                         color: '#111827',
                       }}
                     >
-                      {data.symbol}
+                      {unitCurrency}
                     </span>
                   </div>
                 </div>

--- a/pages/tx/[id].tsx
+++ b/pages/tx/[id].tsx
@@ -98,6 +98,8 @@ export const getServerSideProps: GetServerSideProps = async (ctx) => {
     usd_amount: mochiUtils.formatUsdDigit(transfer.usd_amount),
     date: '',
     external_id: transfer.external_id,
+    moniker: transfer.metadata.moniker || '',
+    original_amount: transfer.metadata.original_amount || '',
   }
 
   if (transfer) {
@@ -137,9 +139,14 @@ export default function Transfer({
   receiver: string
   tokenIcon: string
 }) {
-  const amountDisplay = mochiUtils.formatTokenDigit(
+  const amountSymbol = mochiUtils.formatTokenDigit(
     utils.formatUnits(transfer.amount, transfer.token.decimal),
-  )
+    )
+  const amountDisplay = transfer.metadata.moniker ? transfer.metadata.original_amount : amountSymbol
+  const unitCurrency = transfer.metadata.moniker ? transfer.metadata.moniker : transfer.token.symbol
+  const amountApproxMoniker = transfer.metadata.moniker ? `${amountSymbol} ${transfer.token.symbol}` : ``
+  const amountSection = transfer.metadata.moniker ? `${amountDisplay} ${transfer.metadata.moniker}` : `${amountSymbol}`
+  const unitAmountSection = transfer.metadata.moniker ? `(${amountSymbol} ${transfer.token.symbol})` : `${transfer.token.symbol}`
   const isLongNumber = amountDisplay.length >= 12
 
   return (
@@ -152,7 +159,7 @@ export default function Transfer({
             JSON.stringify(ogData),
           )}`}
           description={`${sender.value} paid ${receiver} ${amountDisplay} ${
-            transfer.token.symbol
+            unitCurrency
           }${
             transfer.metadata.message
               ? ` with message: "${transfer.metadata.message}"`
@@ -200,7 +207,7 @@ export default function Transfer({
               <span className="font-medium">{sender.value}</span>
               <br />
               <span className="text-xs font-light text-gray-500">
-                made a payment
+                sent
               </span>
             </div>
             <div className="flex justify-center items-center mt-8 font-medium">
@@ -234,12 +241,12 @@ export default function Transfer({
                     src={tokenIcon ?? coinIcon.src}
                     alt=""
                   />
-                  <div className="text-4xl">{transfer.token.symbol}</div>
+                  <div className="text-4xl">{unitCurrency}</div>
                 </div>
               </div>
             </div>
             <span className="text-xl">
-              &asymp; {mochiUtils.formatUsdDigit(transfer.usd_amount)}
+              {amountApproxMoniker} &asymp; {mochiUtils.formatUsdDigit(transfer.usd_amount)}
             </span>
           </div>
           {transfer.metadata.message && (
@@ -265,9 +272,9 @@ export default function Transfer({
                 <li className="flex gap-x-3 justify-between">
                   <span className="font-normal text-current">Amount</span>
                   <span className="font-normal text-current">
-                    {amountDisplay}
+                    {amountSection}
                     <span className="ml-1 font-normal text-current">
-                      {transfer.token.symbol}
+                      {unitAmountSection}
                     </span>
                   </span>
                 </li>


### PR DESCRIPTION
- [x] Fix error show wrong moniker amount
Ex: 1 phuclong = 0.01 ftm. If use `amountDisplay` then will show 0.01 phuclong ~ 0.01 ftm -> split amount
<img width="522" alt="image" src="https://github.com/consolelabs/mochi-web/assets/39881166/5bed35ce-ec93-486e-a0ab-7c066a7fd977">

- [x] Show tip moniker
![image](https://github.com/consolelabs/mochi-web/assets/39881166/c5a5285a-70f6-4300-aaf0-441701119bb4)
![image](https://github.com/consolelabs/mochi-web/assets/39881166/2f342d42-26b2-4ab3-9017-a33c30b36905)
![image](https://github.com/consolelabs/mochi-web/assets/39881166/d0f2f658-fc29-4f47-a24e-b29ea9dad0d1)
![image](https://github.com/consolelabs/mochi-web/assets/39881166/95a9c674-b235-4158-9ccd-3a6a6795440f)

